### PR TITLE
fix: Align flush method capitalization with `redis` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,8 +158,8 @@ Currently implemented are the following redis commands:
 * zscore
 
 ### Server
-* flushdb
-* flushall
+* flushDb
+* flushAll
 * time
 
 
@@ -172,7 +172,7 @@ You can therefore run the tests using `redis` instead of `redis-mock`. To do so:
 $ npm test:valid
 ````
 
-You will need to have a running instance of `redis` on you machine and our tests use flushdb a lot so make sure you don't have anything important on it.
+You will need to have a running instance of `redis` on you machine and our tests use flushDb a lot so make sure you don't have anything important on it.
 
 
 # Roadmap

--- a/lib/client/redis-client.js
+++ b/lib/client/redis-client.js
@@ -698,16 +698,16 @@ RedisClient.prototype.select = function (databaseIndex, callback) {
   }
 };
 
-RedisClient.prototype.flushdb = RedisClient.prototype.FLUSHDB = function (callback) {
-  this._selectedDb.flushdb(callback);
+RedisClient.prototype.flushDb = RedisClient.prototype.FLUSHDB = function (callback) {
+  this._selectedDb.flushDb(callback);
 };
 
 RedisClient.prototype.time = RedisClient.prototype.TIME = function (callback) {
   this._selectedDb.time(callback);
 };
 
-RedisClient.prototype.flushall = RedisClient.prototype.FLUSHALL = function (callback) {
-  helpers.callCallback(callback, null, this._redisMock.flushall(callback));
+RedisClient.prototype.flushAll = RedisClient.prototype.FLUSHALL = function (callback) {
+  helpers.callCallback(callback, null, this._redisMock.flushAll(callback));
 };
 
 RedisClient.prototype.auth = RedisClient.prototype.AUTH = function (password, callback) {

--- a/lib/server/redis-db.js
+++ b/lib/server/redis-db.js
@@ -8,7 +8,7 @@ class RedisDb {
     this.storage = {};
   }
 
-  flushdb(callback) {
+  flushDb(callback) {
     this.storage = {};
 
     helpers.callCallback(callback, null, 'OK');

--- a/lib/server/redis-mock.js
+++ b/lib/server/redis-mock.js
@@ -20,8 +20,8 @@ class RedisMock extends events.EventEmitter {
     return this._databases[id];
   }
 
-  flushall() {
-    this._databases.forEach((db) => db.flushdb());
+  flushAll() {
+    this._databases.forEach((db) => db.flushDb());
 
     return 'OK';
   }

--- a/test/client/redis-mock.batch.test.js
+++ b/test/client/redis-mock.batch.test.js
@@ -10,7 +10,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.connection.test.js
+++ b/test/client/redis-mock.connection.test.js
@@ -8,7 +8,7 @@ describe("select", () => {
   describe('When selecting the db through the select() call', () => {
 
     const r = helpers.createClient();
-    afterEach((done) => r.flushall(done));
+    afterEach((done) => r.flushAll(done));
     after((done) => r.quit(done));
 
     it('Then the previously specified keys should not be visible', (done) => {
@@ -99,7 +99,7 @@ describe("select", () => {
     });
 
     afterEach((done) => {
-      c1.flushall(() => c2.flushall(() => c1.quit(() => c2.quit(done))));
+      c1.flushAll(() => c2.flushAll(() => c1.quit(() => c2.quit(done))));
     });
 
     it('When 2 clients point to the same redis instance, but 2 different dbs, Then they do not see each other\'s keys', (done) => {
@@ -126,7 +126,7 @@ describe("select", () => {
     });
 
     afterEach((done) => {
-      subscriber.flushall(() => publisher.flushall(() => subscriber.quit(() => publisher.quit(done))));
+      subscriber.flushAll(() => publisher.flushAll(() => subscriber.quit(() => publisher.quit(done))));
     });
 
     it('When publishing, Then the subscribers on the same db are notified', (done) => {

--- a/test/client/redis-mock.hash.test.js
+++ b/test/client/redis-mock.hash.test.js
@@ -8,7 +8,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.keys.test.js
+++ b/test/client/redis-mock.keys.test.js
@@ -10,7 +10,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.list.test.js
+++ b/test/client/redis-mock.list.test.js
@@ -8,7 +8,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.multi.test.js
+++ b/test/client/redis-mock.multi.test.js
@@ -9,7 +9,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.script.test.js
+++ b/test/client/redis-mock.script.test.js
@@ -12,7 +12,7 @@ describe('Given the script command', () => {
   });
 
   afterEach((done) => {
-    redis.flushall(() => {
+    redis.flushAll(() => {
       done();
     });
   });

--- a/test/client/redis-mock.server.test.js
+++ b/test/client/redis-mock.server.test.js
@@ -10,7 +10,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 
@@ -66,12 +66,12 @@ describe("select", function () {
   });
 });
 
-describe("flushdb", function () {
+describe("flushDb", function () {
 
   it("should clean the current database", function (done) {
 
     r.set("foo", "bar", function (err, result) {
-      r.flushdb(function (err, result) {
+      r.flushDb(function (err, result) {
         result.should.equal("OK");
 
         r.exists("foo", function (err, result) {
@@ -91,7 +91,7 @@ describe("flushdb", function () {
     r.select(0, function (err, result) {
       r.set("a", "1", function (err, result) {
         r.select(3, function (err, result) {
-          r.flushdb(function (err, result) {
+          r.flushDb(function (err, result) {
             r.select(0, function (err, result) {
               r.get("a", function (err, result) {
                 result.should.be.equal("1");

--- a/test/client/redis-mock.set.test.js
+++ b/test/client/redis-mock.set.test.js
@@ -9,7 +9,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.sortedset.test.js
+++ b/test/client/redis-mock.sortedset.test.js
@@ -19,7 +19,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.strings.test.js
+++ b/test/client/redis-mock.strings.test.js
@@ -10,7 +10,7 @@ beforeEach(function () {
 });
 
 afterEach(function (done) {
-  r.flushall();
+  r.flushAll();
   r.quit(done);
 });
 

--- a/test/client/redis-mock.test.js
+++ b/test/client/redis-mock.test.js
@@ -6,7 +6,7 @@ const redismock = require("../../lib");
 // Clean the db after each test
 afterEach(function (done) {
   var r = helpers.createClient();
-  r.flushdb(function () {
+  r.flushDb(function () {
     r.end(true);
     done();
   });


### PR DESCRIPTION
The redis package uses camel-casing for the flush methods (see https://github.com/redis/node-redis/blob/master/packages/client/lib/client/commands.ts#L261).

Code using the all lower-case `flushdb` and `flushall` will need to be updated to use the camel-case `flushDb` and `flushAll`